### PR TITLE
Remove reference to Drupal 8 in project description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "drupal/recommended-project",
-    "description": "Project template for Drupal 8 projects with a relocated document root",
+    "description": "Project template for Drupal 9 projects with a relocated document root",
     "type": "project",
     "license": "GPL-2.0-or-later",
     "homepage": "https://www.drupal.org/project/drupal",


### PR DESCRIPTION
Do we even need a version number in here anymore?

And if this is the recommended layout do we need to mention the "relocated" document root, or should that be considered standard?