### PR TITLE
Changing the Installation Steps documentation URL to latest generic one on the D9 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
                 "",
                 "<bg=yellow;fg=black>Next steps</>:",
 
-                "  * Install the site: https://www.drupal.org/docs/8/install",
+                "  * Install the site: https://www.drupal.org/docs/installing-drupal",
                 "  * Read the user guide: https://www.drupal.org/docs/user_guide/en/index.html",
                 "  * Get support: https://www.drupal.org/support",
                 "  * Get involved with the Drupal community:",


### PR DESCRIPTION
Changing from the D8-specific URL https://www.drupal.org/docs/8/install (which is already being redirected correctly) to the generic one here: https://www.drupal.org/docs/installing-drupal.