### PR TITLE
Allow plugins as per https://getcomposer.org/doc/06-config.md#allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "drush/drush": true,
             "composer/installers": true,
             "drupal/*": true
         }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,12 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "drush/drush": true,
+            "composer/installers": true,
+            "drupal/*": true
+        }
     },
     "extra": {
         "drupal-scaffold": {


### PR DESCRIPTION
https://www.drupal.org/docs/develop/using-composer/manage-dependencies states "For Drupal 9, use the composer template at drupal/recommended-project. This template ensures Drupal Core dependencies are the exact same version as the official Drupal release." However starting on July 1st, 2022, this fails without explicitly allowing certain components, as per https://getcomposer.org/doc/06-config.md#allow-plugins.